### PR TITLE
Fix/reauth token not exists

### DIFF
--- a/src/pages/api/login/index.ts
+++ b/src/pages/api/login/index.ts
@@ -3,14 +3,16 @@ import { createCustomToken } from '../lib/firebaseAuth'
 
 import { getSecrets } from '../lib/secrets'
 import { isValidAccessToken } from '../notion/types'
+import { createUserClient } from '../notion/util'
 
 export type LoginResponse = {
   customToken: string | null
 }
 export default async function handler(req: NextApiRequest, res: NextApiResponse<LoginResponse>) {
   const token = getSecrets(req, 'notion')
+  const notion = await createUserClient(req)
 
-  if (isValidAccessToken(token)) {
+  if (isValidAccessToken(token) && notion) {
     const customToken = await createCustomToken(token.bot_id)
     res.status(200).json({ customToken })
   } else {

--- a/src/pages/api/login/notion.ts
+++ b/src/pages/api/login/notion.ts
@@ -43,6 +43,7 @@ export default async function oauth(
     })
       .then(async (result) => {
         const value = (await result.json()) as AccessTokenResponse
+        console.log(value)
 
         if (isErrorResponse(value)) {
           res?.status(400).json({ success: false, error: value.error })

--- a/src/pages/api/notion/util.ts
+++ b/src/pages/api/notion/util.ts
@@ -10,7 +10,7 @@ const createClient = (token: string) => {
 
 export const createUserClient = async (req: NextApiRequest) => {
   const token = getSecrets(req, 'notion')
-  console.log(token)
+
   if (isValidAccessToken(token)) {
     try {
       const client = createClient(token.access_token)

--- a/src/pages/api/notion/util.ts
+++ b/src/pages/api/notion/util.ts
@@ -10,11 +10,16 @@ const createClient = (token: string) => {
 
 export const createUserClient = async (req: NextApiRequest) => {
   const token = getSecrets(req, 'notion')
-
+  console.log(token)
   if (isValidAccessToken(token)) {
-    const client = createClient(token.access_token)
-    await client.users.me({})
-    return client
+    try {
+      const client = createClient(token.access_token)
+      await client.users.me({})
+      return client
+    } catch {
+      // throw exception when access token is invalid
+      return null
+    }
   }
 
   return null

--- a/src/pages/login/notion.tsx
+++ b/src/pages/login/notion.tsx
@@ -28,11 +28,11 @@ const Callback: NextPage = () => {
         .catch((e) => {
           console.error(e)
         })
-        .finally(() => router.push('/'))
+        .finally(() => router.replace('/'))
     } else if (data?.success === false || error) {
       console.error('error')
       console.error(data?.error || error?.message)
-      router.push('/')
+      router.replace('/')
     }
   }, [auth, data, db, error, router])
 


### PR DESCRIPTION
Notion からコールバックした先のURLをヒストリーに組み込まないように変更
戻ったときにAccessToken をもう一度得ようとすると、AccessToken が無効になってしまうため